### PR TITLE
chore(deps): update renovate config

### DIFF
--- a/package.json
+++ b/package.json
@@ -27,15 +27,13 @@
   "renovate": {
     "extends": [
       "config:application",
-      "schedule:weekends"
-    ],
-    "timezone": "Europe/Paris",
-    "semanticCommits": true,
-    "rebaseStalePrs": true,
-    "minor": {
-      "automerge": true,
-      "automergeType": "branch-push"
-    }
+      "schedule:weekends",
+      ":automergeMinor",
+      ":automergeBranchPush",
+      ":semanticCommits",
+      ":rebaseStalePrs",
+      ":timezone(Europe/Paris)"
+    ]
   },
   "workspaces": [
     "src/*"


### PR DESCRIPTION
This PR refactors the existing Renovate config to use 100% config presets. In doing so it will also resolve the problem found by @vvo in https://github.com/algolia/community-project-boilerplate/pull/3#issuecomment-349442768, where patches were not being branch automerged.
